### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-node_modules
-*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
+  - "10"
 after_success:
    - gulp coveralls

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -21,8 +21,10 @@ export default async function authorize (insecure) {
     log.info(`Updating security db for ` +
                 `${insecure ? 'insecure' : 'developer'} access`);
     let cmd = 'security';
-    let args = ['authorizationdb', 'write', 'system.privilege.taskport',
-                (insecure ? 'allow' : 'is-developer')];
+    let args = [
+      'authorizationdb', 'write', 'system.privilege.taskport',
+      (insecure ? 'allow' : 'is-developer'),
+    ];
     await exec(cmd, args);
 
     log.info('Granting access to built-in simulator apps');
@@ -30,7 +32,7 @@ export default async function authorize (insecure) {
       throw new Error('Could not determine your $HOME');
     }
 
-    user = /\/([^\/]+)$/.exec(process.env.HOME)[1];
+    user = /\/([^/]+)$/.exec(process.env.HOME)[1];
     xcodeDir = await getPath();
     log.info(`The xcode directory is : ${xcodeDir}`);
   } catch (e) {
@@ -62,4 +64,4 @@ export default async function authorize (insecure) {
                  `for iOS sim app dirs: ${directories}`);
     log.error(`Error was: ${err.message}`);
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -24,10 +24,18 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "authorize-ios.js",
+    "index.js",
+    "lib",
+    "build/authorize-ios.js",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-support": "^2.5.0",
     "appium-xcode": "^3.0.0",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "glob": "^7.1.2",
     "lodash": "^4.17.10",
@@ -36,7 +44,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "watch": "gulp watch",
     "lint": "gulp lint",
@@ -48,32 +56,22 @@
     "precommit-test"
   ],
   "devDependencies": {
-    "appium-gulp-plugins": "^2.4.0",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.1.0",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.11",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "mocha": "^5.1.1",
     "pre-commit": "^1.2.2",
     "sinon": "^6.0.0"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.